### PR TITLE
fix: add all types to history argument as default

### DIFF
--- a/src/zabbix_mcp_server.py
+++ b/src/zabbix_mcp_server.py
@@ -931,23 +931,25 @@ def event_acknowledge(
 @mcp.tool()
 def history_get(
     itemids: List[str],
-    history: int = 0,
+    history: List[int] = [0, 1, 3, 4],
     time_from: Optional[int] = None,
     time_till: Optional[int] = None,
-    limit: Optional[int] = None,
+    limit: Optional[int] = 10,
     sortfield: str = "clock",
     sortorder: str = "DESC",
 ) -> str:
     """Get history data from Zabbix.
 
-    This tool retrieves historical monitoring data for specified items. History data includes timestamped values collected over time. Use time ranges and limits to manage response size, as large queries can fail due to excessive data.
+    This tool retrieves historical monitoring data for specified items.
+    History data includes timestamped values collected over time.
+    Use time ranges and limits to manage response size, as large queries can fail due to excessive data.
 
     Args:
         itemids: Required list of item IDs (as strings) to get history for. Example: ["23296", "23297"]. If unknown, use item_get to find item IDs first or ask the user.
         history: Type of history data: 0=float (default), 1=string, 2=log, 3=integer, 4=text. Choose based on the item's value_type.
         time_from: Optional start time as Unix timestamp (integer). If unknown, calculate from a known date or ask the user.
         time_till: Optional end time as Unix timestamp (integer). If unknown, calculate from a known date or ask the user.
-        limit: Optional integer to limit the number of returned values. Strongly recommended (e.g., 1000) to avoid failures from massive datasets.
+        limit: Optional integer to limit the number of returned values. Strongly recommended (e.g., 10) to avoid failures from massive datasets.
         sortfield: Field to sort by, e.g., "clock" (default) for timestamp.
         sortorder: Sort order: "DESC" (default) for newest first, or "ASC".
 
@@ -955,9 +957,11 @@ def history_get(
         str: JSON formatted list of history data points, each with timestamp, value, etc.
 
     Notes:
+        - Always request all data types except logs (2). Yo can change this parameter only if requested from the human operator.
         - Queries without time_from/time_till or limit can return enormous amounts of data (e.g., years of metrics), causing failures. Always specify a narrow time range and limit.
         - Type errors are common; ensure itemids are strings in a list and timestamps are integers. If unsure, use item_get to verify item details.
-        - Example usage: history_get(itemids=["23296"], history=0, time_from=1690000000, time_till=1691000000, limit=1000, sortorder="ASC") to get up to 1000 float values for an item in a time range, sorted oldest first.
+        - Example usage: history_get(itemids=["23296"], history=[0, 1, 3, 4], time_from=1690000000, time_till=1691000000, limit=10, sortorder="ASC")
+        to get up to 10  values from all types that we usually use or that was requested for an item in a time range, sorted oldest first.
     """
     client = get_zabbix_client()
     params = {


### PR DESCRIPTION
Fixing history_get tool to receive, as default, all data types that we use in SenseiNode's zabbix configuration.
